### PR TITLE
feat(pgdialect): add support for RETURNING clause in MERGE statements

### DIFF
--- a/dialect/feature/feature.go
+++ b/dialect/feature/feature.go
@@ -41,6 +41,7 @@ const (
 	DeleteOrderLimit // DELETE ... ORDER BY ... LIMIT ...
 	DeleteReturning
 	AlterColumnExists // ADD/DROP COLUMN IF NOT EXISTS/IF EXISTS
+	MergeReturning
 )
 
 type NotSupportError struct {

--- a/dialect/pgdialect/go.mod
+++ b/dialect/pgdialect/go.mod
@@ -1,12 +1,15 @@
 module github.com/uptrace/bun/dialect/pgdialect
 
-go 1.22.0
+go 1.23.0
+
+toolchain go1.24.2
 
 replace github.com/uptrace/bun => ../..
 
 require (
 	github.com/stretchr/testify v1.8.1
 	github.com/uptrace/bun v1.2.11
+	golang.org/x/mod v0.24.0
 )
 
 require (

--- a/dialect/pgdialect/go.sum
+++ b/dialect/pgdialect/go.sum
@@ -25,6 +25,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/dbtest/docker-compose.yaml
+++ b/internal/dbtest/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       interval: 10s
       retries: 3
   postgres:
-    image: postgres:15
+    image: postgres:17
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/internal/dbtest/go.mod
+++ b/internal/dbtest/go.mod
@@ -68,7 +68,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/exp v0.0.0-20250228200357-dead58393ab7 // indirect
-	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/dbtest/go.sum
+++ b/internal/dbtest/go.sum
@@ -414,6 +414,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
 golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/query_merge.go
+++ b/query_merge.go
@@ -214,6 +214,14 @@ func (q *MergeQuery) AppendQuery(fmter schema.Formatter, b []byte) (_ []byte, er
 		}
 	}
 
+	if q.hasFeature(feature.MergeReturning) && q.hasReturning() {
+		b = append(b, " RETURNING "...)
+		b, err = q.appendReturning(fmter, b)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// A MERGE statement must be terminated by a semi-colon (;).
 	b = append(b, ";"...)
 
@@ -252,7 +260,7 @@ func (q *MergeQuery) scanOrExec(
 		return nil, err
 	}
 
-	useScan := hasDest || (q.hasReturning() && q.hasFeature(feature.InsertReturning|feature.Output))
+	useScan := hasDest || (q.hasReturning() && q.hasFeature(feature.InsertReturning|feature.MergeReturning|feature.Output))
 	var model Model
 
 	if useScan {


### PR DESCRIPTION
This PR adds support for RETURNING clauses in MERGE statements specifically for PostgreSQL databases. PostgreSQL has supported the RETURNING clause in MERGE statements since version 17. (see: [Changelog](https://www.postgresql.org/docs/current/release-17.html#RELEASE-17-MERGE))

Changes:

- Introduce `feature.MergeReturning` since the feature is only supported from PG v17 on onwards.
- Add `feature.MergeReturning` to mysql dialect for PostgreSQL 17 and later

Example usage:
```
type Model struct {
	ID    int64 `bun:",pk,autoincrement"`
	Name  string
	Value string
}

newModels := []*Model{
	{Name: "A", Value: "world"},
	{Name: "B", Value: "test"},
}

return db.NewMerge().
	Model(new(Model)).
	With("_data", db.NewValues(&newModels)).
	Using("_data").
	On("?TableAlias.name = _data.name").
	WhenUpdate("MATCHED", func(q *bun.UpdateQuery) *bun.UpdateQuery {
		return q.Set("value = _data.value")
	}).
	WhenInsert("NOT MATCHED", func(q *bun.InsertQuery) *bun.InsertQuery {
		return q.Value("name", "_data.name").Value("value", "_data.value")
	}).
	Returning("id")
```
References:

[PostgreSQL 17 Release Notes](https://www.postgresql.org/docs/current/release-17.html)